### PR TITLE
Supress Powershell popping up in pyinstaller .exe

### DIFF
--- a/notifypy/os_notifiers/windows.py
+++ b/notifypy/os_notifiers/windows.py
@@ -116,7 +116,9 @@ $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
             ) as ps1_file:
                 ps1_file.write(generated_file)
             # exceute the file
-            subprocess.call(
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            subprocess.Popen(
                 [
                     "Powershell",
                     "-ExecutionPolicy",
@@ -125,5 +127,6 @@ $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
                     f"{generated_uuid_file}.ps1",
                 ],
                 cwd=temp_dir,
-            )
+                startupinfo=startupinfo,
+            ).wait()
         return True


### PR DESCRIPTION
Hi, I noticed a bug of notify-py in combination with [PyInstaller](http://www.pyinstaller.org/) on Windows (10):
If a program using notify-py is compiled to an `.exe` with the ``--windowed`` flag, the powershell windows pop's up for second when a notification is shown.

This commit should fix it.

To reproduce:
1. Deps:
    ```bash
    pip install pyinstaller notify-py
    ```
2. Create test.py:
    ```python
    from notifypy import Notify
    notification = Notify()
    notification.send(block=False)
    ```
3. Compile to .exe:
    ```bash
    pyinstaller --windowed test.py
    ```
4. Run `./dist/test/test.exe`

Result:
![powershell](https://user-images.githubusercontent.com/11071876/97894726-236fd000-1d33-11eb-92d7-09b8bfb829d5.gif)
