### PR TITLE
Exclude tests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/ms7m/notify-py",
     python_requires=">=3.6.0",
     packages=find_packages(
-        exclude=["testing", "*.testing", "*.testing.*", "testing.*"]
+        exclude=["testing", "*.testing", "*.testing.*", "testing.*", "tests"]
     ),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
While packaging your library for gentoo, portage complained about your package installing a tests package.

To be honest I don't understand python build systems but this change seems to be in line with the other excluded package names and it makes my package manager happy.