### PR TITLE
Inherit correct Exception class

### DIFF
--- a/notifypy/exceptions.py
+++ b/notifypy/exceptions.py
@@ -1,7 +1,7 @@
 # Custom and Clear Exceptions for NotifyPy
 
 
-class BaseNotifyPyException(BaseException):
+class BaseNotifyPyException(Exception):
     """Base Exception to be Inheritied"""
 
 


### PR DESCRIPTION
From [Python documentation](https://docs.python.org/3/library/exceptions.html#BaseException):

>  _exception_ **BaseException**
> The base class for all built-in exceptions. It is not meant to be directly inherited by user-defined classes (for that, use Exception).