### PR TITLE
Improvements | notify-send | Urgerncy | Which | BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ You may need to add ``python3 -m`` to the beginning.
 - [Leterax](https://github.com/Leterax)
 - [jnoortheen](https://github.com/jnoortheen)
 - [dynobo](https://github.com/dynobo)
+- [Xou](https://github.com/GiorgosXou)
 
 ---
 

--- a/notifypy/__init__.py
+++ b/notifypy/__init__.py
@@ -1,4 +1,4 @@
 from .notify import Notify
 from .os_notifiers._base import BaseNotifier
 
-__version__ = "0.3.31"
+__version__ = "0.3.38"

--- a/notifypy/exceptions.py
+++ b/notifypy/exceptions.py
@@ -1,7 +1,7 @@
 # Custom and Clear Exceptions for NotifyPy
 
 
-class BaseNotifyPyException(BaseException):
+class BaseNotifyPyException(Exception):
     """Base Exception to be Inheritied"""
 
 

--- a/notifypy/notify.py
+++ b/notifypy/notify.py
@@ -256,7 +256,7 @@ class Notify:
     @property
     def urgency(self):
         """The urgency of the notification (low, normal, critical) 
-        Work only with libnotify (Linux), as of now
+        Works only with libnotify (Linux), as of now
 
         Returns:
             str: The urgency of the notification.

--- a/notifypy/notify.py
+++ b/notifypy/notify.py
@@ -23,6 +23,7 @@ class Notify:
         default_notification_title="Default Title",
         default_notification_message="Default Message",
         default_notification_application_name="Python Application (notify.py)",
+        default_notification_urgency='normal',
         default_notification_icon=None,
         default_notification_audio=None,
         enable_logging=False,
@@ -74,6 +75,7 @@ class Notify:
         self._notification_title = default_notification_title
         self._notification_message = default_notification_message
         self._notification_application_name = default_notification_application_name
+        self._notification_urgency = default_notification_urgency
 
         # These defaults require verification
         if default_notification_icon:
@@ -111,16 +113,17 @@ class Notify:
                 return LinuxNotifierLibNotify
             else:
 
-                from .os_notifiers.linux import USE_LEGACY
+                from .os_notifiers.linux import NOTIFY
 
-                if USE_LEGACY == False:
-                    from .os_notifiers.linux import LinuxNotifier
-
-                    return LinuxNotifier
-                else:
+                if NOTIFY:
                     from .os_notifiers.linux import LinuxNotifierLibNotify
 
                     return LinuxNotifierLibNotify
+                else:
+                    from .os_notifiers.linux import LinuxNotifier
+
+                    return LinuxNotifier
+
         elif selected_platform == "Darwin":
             from .os_notifiers.macos import MacOSNotifier
 
@@ -250,6 +253,20 @@ class Notify:
     def application_name(self, new_application_name):
         self._notification_application_name = new_application_name
 
+    @property
+    def urgency(self):
+        """The urgency of the notification (low, normal, critical) 
+        Work only with libnotify (Linux), as of now
+
+        Returns:
+            str: The urgency of the notification.
+        """
+        return self._notification_urgency
+
+    @urgency.setter
+    def urgency(self, new_urgency):
+        self._notification_urgency = new_urgency
+
     def send(self, block=True):
         """Main send function. This will take all attributes sent and forward to
         send_notification.
@@ -288,6 +305,7 @@ class Notify:
             supplied_title=self._notification_title,
             supplied_message=self._notification_message,
             supplied_application_name=self._notification_application_name,
+            supplied_urgency=self._notification_urgency,
             supplied_icon_path=self._notification_icon,
             supplied_audio_path=self._notification_audio,
         )
@@ -301,6 +319,7 @@ class Notify:
         supplied_title,
         supplied_message,
         supplied_application_name,
+        supplied_urgency,
         supplied_icon_path,
         supplied_audio_path,
     ):
@@ -310,6 +329,7 @@ class Notify:
             supplied_title str: Title for notification
             supplied_message str: Message for notification
             supplied_application_name str: Application name for notification (if platform needs it)
+            supplied_urgency str: low, normal, critical | Notification urgency
             supplied_icon_path str: Direct path to custom icon
             supplied_audio_path str: Direct path to custom audio
 
@@ -324,6 +344,7 @@ class Notify:
                 notification_title=str(supplied_title),
                 notification_subtitle=str(supplied_message),
                 application_name=str(supplied_application_name),
+                notification_urgency=str(supplied_urgency),
                 notification_icon=str(supplied_icon_path),
                 notification_audio=str(supplied_audio_path)
                 if supplied_audio_path

--- a/notifypy/notify.py
+++ b/notifypy/notify.py
@@ -105,26 +105,7 @@ class Notify:
         else:
             selected_platform = platform.system()
 
-        if selected_platform == "Linux":
-
-            if linux_use_legacy_notifier:
-                from .os_notifiers.linux import LinuxNotifierLibNotify
-
-                return LinuxNotifierLibNotify
-            else:
-
-                from .os_notifiers.linux import NOTIFY
-
-                if NOTIFY:
-                    from .os_notifiers.linux import LinuxNotifierLibNotify
-
-                    return LinuxNotifierLibNotify
-                else:
-                    from .os_notifiers.linux import LinuxNotifier
-
-                    return LinuxNotifier
-
-        elif selected_platform == "Darwin":
+        if selected_platform == "Darwin":
             from .os_notifiers.macos import MacOSNotifier
 
             return MacOSNotifier
@@ -143,9 +124,25 @@ class Notify:
                 f"This version of Windows ({platform.release()}) is not supported."
             )
         else:
-            raise UnsupportedPlatform(
-                "Platform couldn't be detected, please manually specifiy platform."
-            )
+            if selected_platform != "Linux":
+                logger.warning(f'{selected_platform} might not be supported!')
+
+            if linux_use_legacy_notifier:
+                from .os_notifiers.linux import LinuxNotifierLibNotify
+
+                return LinuxNotifierLibNotify
+            else:
+
+                from .os_notifiers.linux import NOTIFY
+
+                if NOTIFY:
+                    from .os_notifiers.linux import LinuxNotifierLibNotify
+
+                    return LinuxNotifierLibNotify
+                else:
+                    from .os_notifiers.linux import LinuxNotifier
+
+                    return LinuxNotifier
 
     @staticmethod
     def _verify_audio_path(new_audio_path):

--- a/notifypy/os_notifiers/windows.py
+++ b/notifypy/os_notifiers/windows.py
@@ -92,6 +92,7 @@ $toast = New-Object Windows.UI.Notifications.ToastNotification $xml
         notification_icon,
         application_name,
         notification_audio,
+        **kwargs,
     ):
         generated_file = self._generate_notification_xml(
             notification_title=notification_title,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notify_py"
-version = "0.3.31"
+version = "0.3.38"
 description = "Cross-platform desktop notification library for Python"
 authors = ["Mustafa Mohamed <mustafa@ms7m.me>"]
 repository = "https://github.com/ms7m/notify-py"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="notify_py",
-    version="0.3.31",
+    version="0.3.38",
     author="Mustafa Mohamed",
     author_email="ms7mohamed@gmail.com",
     description="Cross-platform desktop notification library for Python",


### PR DESCRIPTION
https://github.com/ms7m/notify-py/blob/f748189a2e8b4b147fcbf1acb6912c944d687671/notifypy/os_notifiers/linux.py#L33

* ***Added:*** notification urgency *(low, normal, critical)* for `notify-send`
* ***Fixed:*** `notify-send`, now is being used as the first choice if installed
* ***Fixed:*** OSs like [BSD](https://github.com/ms7m/notify-py/issues/13) now default under the linux-behavioural category
* ***Fixed:*** issue under windows with extra `kwargs` that resulted in error 
* ***Removed:*** `linux_fallback_libnotify`, no more need for it
* ***Replaced:*** functions with the in-built `shutil.which` function

***PS.** Tried not to be messy with the code and respect your overall structural patterns. It has been tested and works fine both on linux and on windows (+the in-built `shutil.which` function works with BSD too)*