### PR TITLE
Install notifypy CLI script with poetry as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ black = "^20.8b1"
 typed-ast = "1.5.2"
 pylint = "*"
 
+[tool.poetry.scripts]
+notifypy = "notifypy.cli:entry"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-


### PR DESCRIPTION
It looks like the switch from setuptools to poetry broke the CLI script install, as that was only specified in `setup.py`. This change adds the appropriate `[tool.poetry.scripts]` entry to `pyproject.toml` so that will happen again:

```
~/code/notify-py (wisnij/20230102-poetry-install-cli=) $ pip install . -v
Using pip 22.3.1 from /usr/lib/python3/dist-packages/pip (python 3.10)
[...]
Successfully built notify-py
Installing collected packages: notify-py
  changing mode of /home/wisnij/.local/bin/notifypy to 755
Successfully installed notify-py-0.3.38
```