### PR TITLE
fix: UnsupportedPlatform exception on Windows 11 and Python 3.12

### DIFF
--- a/notifypy/notify.py
+++ b/notifypy/notify.py
@@ -110,7 +110,7 @@ class Notify:
 
             return MacOSNotifier
         elif selected_platform == "Windows":
-            if platform.release() == "10":
+            if platform.release() in {"10", "11"}:
                 from .os_notifiers.windows import WindowsNotifier
 
                 return WindowsNotifier


### PR DESCRIPTION
![](https://github.com/ms7m/notify-py/assets/47057319/f3c1a7a6-dcdf-4866-b630-142e7ed2e1f5)

It seems that `platform.release()` will return `'11'` on Windows 11 instead of `'10'` in Python 3.12, which leads to an unexpected `UnsupportedPlatform` exception. I created this PR to fix the detection code.